### PR TITLE
Added requestAuthorization func to objc and js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,14 @@ const GalleryManager = {
     },
 
     /**
+     * To Request authorization for access photos
+     * returns Promise
+     */
+    requestAuthorization() {
+        return RNGalleryManager.requestAuthorization();
+    },
+
+    /**
      * Get List with album names
      */
     getAlbums() {

--- a/ios/RNGalleryManager.m
+++ b/ios/RNGalleryManager.m
@@ -150,6 +150,17 @@ RCT_EXPORT_METHOD(getAlbums: (RCTPromiseResolveBlock)resolve
   
 }
 
+/* To Request Authorization for photos */
+RCT_EXPORT_METHOD(requestAuthorization:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+    
+    resolve(@{
+              @"isAuthorized" : @((BOOL)(status == PHAuthorizationStatusAuthorized))
+              });
+  }];
+}
 
 
 // Get the media type


### PR DESCRIPTION
This is useful to check authorization - if access granted then we can get the photos immediately without refresh of the view. currently not possible.

example usage:

```
GalleryManager.requestAuthorization().then(status => {
            console.log(status);
            if (status.isAuthorized) {
                // get photos
                GalleryManager.getAssets({
                type: 'all',
                limit: 10,
                startFrom: 0
              })
                 .then(r => {
                    console.log(r)
             }
       }
}
```

  