### PR TITLE
Fixed Android package

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="org.pentarex.rngallerymanager">
 
 </manifest>
   

--- a/android/src/main/java/org/pentarex/rngallerymanager/RNGalleryManagerPackage.java
+++ b/android/src/main/java/org/pentarex/rngallerymanager/RNGalleryManagerPackage.java
@@ -10,16 +10,20 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class RNGalleryManagerPackage implements ReactPackage {
+      
+    public RNGalleryManagerPackage() {}
+    
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-      return Arrays.<NativeModule>asList(
-          new RNGalleryManagerModule(reactContext)
-      );
+      List<NativeModule> modules = new ArrayList<>();
+      modules.add(new RNGalleryManagerModule(reactContext));
+      return modules;
     }
 
     // Deprecated RN 0.47


### PR DESCRIPTION
The `AndroidManifest.xml` was using the wrong package, instead of `org.pentarex.rngallerymanager` it was showing `com.reactlibrary` which was causing problems when linking the project on Android because it couldn't be found. Also changed the way the package is imported. It's been tested on Samsung S6 with Android 7 and works fine.